### PR TITLE
Update dependencies and clean up pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,42 +177,42 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.7</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.31</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.31</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.14.1</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.28</version>
+            <version>1.30</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.65.Final</version>
+            <version>4.1.75.Final</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -222,7 +222,7 @@
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>2.9.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>net.cubespace</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
                                     <include>io.netty:*</include>
                                     <include>commons-lang:*</include>
                                     <include>net.cubespace:*</include>
+                                    <include>javax.activation:*</include>
                                 </includes>
                             </artifactSet>
                         </configuration>
@@ -152,6 +153,11 @@
             <groupId>net.cubespace</groupId>
             <artifactId>Yamler-Core</artifactId>
             <version>2.3.1-20150720.092759-2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>javax.activation</artifactId>
+            <version>1.2.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,28 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.0.5</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
+                <version>2.22.1</version>
                 <configuration>
                     <skipTests>true</skipTests>
                 </configuration>
@@ -28,19 +48,19 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>net.cubespace.dynmap.multiserver.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
@@ -55,7 +75,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.4</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -80,18 +100,26 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>net.cubespace.dynmap.multiserver.Main</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.1.0</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.1.0</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.7.1</version>
+      </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -45,7 +44,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
                 <configuration>
                     <skipTests>true</skipTests>
                 </configuration>
@@ -53,7 +51,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -65,7 +62,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -80,7 +76,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -101,37 +96,79 @@
                                     <include>net.cubespace:*</include>
                                 </includes>
                             </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.1.0</version>
-            </plugin>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
-            </plugin>
-            <plugin>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
-            </plugin>
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.1.0</version>
-            </plugin>
-            <plugin>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.7.1</version>
-            </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.9.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M5</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.2.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <repositories>
         <repository>
             <id>md_5-releases</id>
-            <url>http://repo.md-5.net/content/repositories/snapshots/</url>
+            <url>https://repo.md-5.net/repository/public/</url>
         </repository>
     </repositories>
 
@@ -139,52 +176,57 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.8.0-beta2</version>
+            <version>1.7.31</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.8.0-beta2</version>
+            <version>1.7.31</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.23</version>
+            <version>1.28</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>20030203.000550</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.42.Final</version>
+            <version>4.1.65.Final</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>20030203.000129</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>1.3.2</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>net.cubespace</groupId>
             <artifactId>Yamler-Core</artifactId>
-            <version>2.3.1-20150720.092759-2</version>
+            <version>2.4.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,11 @@
     <artifactId>Dynmap-MultiServer</artifactId>
     <version>0.5.0</version>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <build>
         <defaultGoal>clean install</defaultGoal>
         <resources>
@@ -62,8 +67,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <compilerArguments>
                         <O>-Xlint:all</O>
                         <O>-Xlint:-path</O>
@@ -100,26 +105,26 @@
                     </execution>
                 </executions>
             </plugin>
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>3.1.0</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-install-plugin</artifactId>
-        <version>2.5.2</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-site-plugin</artifactId>
-        <version>3.7.1</version>
-      </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>2.5.2</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.7.1</version>
+            </plugin>
         </plugins>
     </build>
 
@@ -134,17 +139,17 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.4</version>
+            <version>2.8.5</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.5</version>
+            <version>1.8.0-beta2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.5</version>
+            <version>1.8.0-beta2</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
@@ -154,7 +159,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.13</version>
+            <version>1.23</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -174,7 +179,7 @@
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
         </dependency>
         <dependency>
             <groupId>net.cubespace</groupId>

--- a/src/main/java/net/cubespace/dynmap/multiserver/AbstractDynmapServer.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/AbstractDynmapServer.java
@@ -95,7 +95,7 @@ public abstract class AbstractDynmapServer implements DynmapServer {
 
     private void loadWorlds() throws DynmapInitException {
         for (DynmapWorld world : dynmapConfig.getWorlds()) {
-            logger.info("Checking World " + world.getName());
+            logger.debug("Checking World " + world.getName());
 
             AbstractFile dynmapWorldConfig = null;
             try {

--- a/src/main/java/net/cubespace/dynmap/multiserver/HTTP/HTTPRouterServerHandler.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/HTTP/HTTPRouterServerHandler.java
@@ -6,11 +6,11 @@ import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequest;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.*;
-import static io.netty.handler.codec.http.HttpHeaders.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
+import static io.netty.handler.codec.http.HttpUtil.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static io.netty.handler.codec.http.HttpVersion.*;
 
@@ -39,7 +39,7 @@ public class HTTPRouterServerHandler extends ChannelHandlerAdapter {
             if (!keepAlive) {
                 ctx.write(response).addListener(ChannelFutureListener.CLOSE);
             } else {
-                response.headers().set(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+                response.headers().set(CONNECTION, HttpHeaderValues.KEEP_ALIVE);
                 ctx.write(response);
             }
         }

--- a/src/main/java/net/cubespace/dynmap/multiserver/HTTP/HTTPServerHandler.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/HTTP/HTTPServerHandler.java
@@ -26,19 +26,19 @@ public class HTTPServerHandler extends SimpleChannelInboundHandler<FullHttpReque
     @Override
     public void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) throws Exception {
         //Check for bad Request
-        if (!request.getDecoderResult().isSuccess()) {
+        if (!request.decoderResult().isSuccess()) {
             HandlerUtil.sendError(ctx, BAD_REQUEST);
             return;
         }
 
         //Check for correct HTTP Method (only GET and POST should work)
-        if (request.getMethod() != GET && request.getMethod() != POST) {
+        if (request.method() != GET && request.method() != POST) {
             HandlerUtil.sendError(ctx, METHOD_NOT_ALLOWED);
             return;
         }
 
         //Check which handler should handle it
-        final String uri = request.getUri();
+        final String uri = request.uri();
         String path = HandlerUtil.sanitizeUri(uri);
         if (path == null) {
             HandlerUtil.sendError(ctx, FORBIDDEN);

--- a/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/ConfigJSHandler.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/ConfigJSHandler.java
@@ -6,17 +6,17 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import net.cubespace.dynmap.multiserver.HTTP.HandlerUtil;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
-import static io.netty.handler.codec.http.HttpHeaders.Names.IF_MODIFIED_SINCE;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderNames.IF_MODIFIED_SINCE;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -65,7 +65,7 @@ public class ConfigJSHandler implements IHandler {
         HandlerUtil.setDateAndCacheHeaders(response, start);
         response.headers().set(CONTENT_TYPE, "application/javascript; charset=UTF-8");
         response.headers().set(CONTENT_LENGTH, response.content().readableBytes());
-        response.headers().set(CONNECTION, HttpHeaders.Values.CLOSE);
+        response.headers().set(CONNECTION, HttpHeaderValues.CLOSE);
 
         ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
     }

--- a/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/DynmapConfigJSONHandler.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/DynmapConfigJSONHandler.java
@@ -7,7 +7,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import net.cubespace.dynmap.multiserver.Config.Main;
 import net.cubespace.dynmap.multiserver.DynmapServer;
 import net.cubespace.dynmap.multiserver.GSON.Component;
@@ -23,7 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -135,7 +135,7 @@ public class DynmapConfigJSONHandler implements IHandler {
         HandlerUtil.setDateAndCacheHeaders(response, start);
         response.headers().set(CONTENT_TYPE, "application/json; charset=UTF-8");
         response.headers().set(CONTENT_LENGTH, response.content().readableBytes());
-        response.headers().set(CONNECTION, HttpHeaders.Values.CLOSE);
+        response.headers().set(CONNECTION, HttpHeaderValues.CLOSE);
 
         ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
     }

--- a/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/FacesFileHandler.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/FacesFileHandler.java
@@ -14,7 +14,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -26,7 +26,7 @@ public class FacesFileHandler implements IHandler {
     public void handle(ChannelHandlerContext ctx, FullHttpRequest request) throws Exception {
         //Get the correct DynmapServer
         for (DynmapServer dynmapServer : Main.getDynmapServers()) {
-            AbstractFile file = dynmapServer.getFile(request.getUri());
+            AbstractFile file = dynmapServer.getFile(request.uri());
             if (file.exists()) {
                 if (file.isHidden() || !file.exists()) {
                     HandlerUtil.sendError(ctx, NOT_FOUND);
@@ -63,7 +63,7 @@ public class FacesFileHandler implements IHandler {
                 HandlerUtil.setDateAndCacheHeaders(response, file.lastModified());
 
                 response.headers().set(CONTENT_LENGTH, file.length());
-                response.headers().set(CONNECTION, HttpHeaders.Values.CLOSE);
+                response.headers().set(CONNECTION, HttpHeaderValues.CLOSE);
                 response.headers().set(VARY, ACCEPT_ENCODING);
 
                 // Write the initial line and the header.

--- a/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/MapConfigHandler.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/MapConfigHandler.java
@@ -7,14 +7,14 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import net.cubespace.dynmap.multiserver.DynmapServer;
 import net.cubespace.dynmap.multiserver.GSON.DynmapWorld;
 import net.cubespace.dynmap.multiserver.GSON.DynmapWorldConfig;
 import net.cubespace.dynmap.multiserver.HTTP.HandlerUtil;
 import net.cubespace.dynmap.multiserver.Main;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
@@ -28,7 +28,7 @@ public class MapConfigHandler implements IHandler {
     @Override
     public void handle(ChannelHandlerContext ctx, FullHttpRequest request) throws Exception {
         //Get the correct DynmapServer
-        String world = request.getUri().split("/")[3].split("\\.")[0];
+        String world = request.uri().split("/")[3].split("\\.")[0];
         for (DynmapServer dynmapServer : Main.getDynmapServers()) {
             for (DynmapWorld dynmapWorld : dynmapServer.getWorlds()) {
                 if (dynmapWorld.getName().equals(world)) {
@@ -43,7 +43,7 @@ public class MapConfigHandler implements IHandler {
                     FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.wrappedBuffer(responseStr.getBytes()));
                     response.headers().set(CONTENT_TYPE, "application/json; charset=UTF-8");
                     response.headers().set(CONTENT_LENGTH, response.content().readableBytes());
-                    response.headers().set(CONNECTION, HttpHeaders.Values.CLOSE);
+                    response.headers().set(CONNECTION, HttpHeaderValues.CLOSE);
 
                     ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
                     return;

--- a/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/MarkerHandler.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/MarkerHandler.java
@@ -13,7 +13,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -25,11 +25,11 @@ public class MarkerHandler implements IHandler {
     public void handle(ChannelHandlerContext ctx, FullHttpRequest request) throws Exception {
         //Get the correct DynmapServer
         AbstractFile path = null;
-        String world = request.getUri().split("/")[3].replace("marker_", "").replace(".json", "");
+        String world = request.uri().split("/")[3].replace("marker_", "").replace(".json", "");
         for (DynmapServer dynmapServer : Main.getDynmapServers()) {
             for (DynmapWorld dynmapWorld : dynmapServer.getWorlds()) {
                 if (dynmapWorld.getName().equals(world)) {
-                    path = dynmapServer.getFile(request.getUri());
+                    path = dynmapServer.getFile(request.uri());
                 }
             }
         }
@@ -68,7 +68,7 @@ public class MarkerHandler implements IHandler {
         HandlerUtil.setDateAndCacheHeaders(response, file.lastModified());
 
         response.headers().set(CONTENT_LENGTH, file.length());
-        response.headers().set(CONNECTION, HttpHeaders.Values.CLOSE);
+        response.headers().set(CONNECTION, HttpHeaderValues.CLOSE);
         response.headers().set(VARY, ACCEPT_ENCODING);
 
         // Write the initial line and the header.

--- a/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/StaticFileHandler.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/StaticFileHandler.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Locale;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -27,8 +27,8 @@ public class StaticFileHandler implements IHandler {
     @Override
     public void handle(ChannelHandlerContext ctx, FullHttpRequest request) throws Exception {
         //Check for index
-        final String path = webDir + File.separator + request.getUri();
-        final String uri = request.getUri();
+        final String path = webDir + File.separator + request.uri();
+        final String uri = request.uri();
         if (uri.endsWith("/")) {
             for (String index : indexFiles) {
                 File checkFile = new File(path, index);
@@ -93,7 +93,7 @@ public class StaticFileHandler implements IHandler {
         HandlerUtil.setDateAndCacheHeaders(response, file.lastModified());
 
         response.headers().set(CONTENT_LENGTH, fileLength);
-        response.headers().set(CONNECTION, HttpHeaders.Values.CLOSE);
+        response.headers().set(CONNECTION, HttpHeaderValues.CLOSE);
         response.headers().set(VARY, ACCEPT_ENCODING);
 
         // Write the initial line and the header.

--- a/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/TileFileHandler.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/HTTP/Handler/TileFileHandler.java
@@ -13,7 +13,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -25,11 +25,11 @@ public class TileFileHandler implements IHandler {
     public void handle(ChannelHandlerContext ctx, FullHttpRequest request) throws Exception {
         //Get the correct DynmapServer
         AbstractFile path = null;
-        String world = request.getUri().split("/")[2];
+        String world = request.uri().split("/")[2];
 
         if (world.equals("_markers_")) {
             for (DynmapServer dynmapServer : Main.getDynmapServers()) {
-                AbstractFile file = dynmapServer.getFile(request.getUri());
+                AbstractFile file = dynmapServer.getFile(request.uri());
                 if (file.exists()) {
                     if (file.isHidden() || !file.exists()) {
                         HandlerUtil.sendError(ctx, NOT_FOUND);
@@ -64,7 +64,7 @@ public class TileFileHandler implements IHandler {
                     HandlerUtil.setDateAndCacheHeaders(response, file.lastModified());
 
                     response.headers().set(CONTENT_LENGTH, file.length());
-                    response.headers().set(CONNECTION, HttpHeaders.Values.CLOSE);
+                    response.headers().set(CONNECTION, HttpHeaderValues.CLOSE);
                     response.headers().set(VARY, ACCEPT_ENCODING);
 
                     // Write the initial line and the header.
@@ -81,7 +81,7 @@ public class TileFileHandler implements IHandler {
         for (DynmapServer dynmapServer : Main.getDynmapServers()) {
             for (DynmapWorld dynmapWorld : dynmapServer.getWorlds()) {
                 if (dynmapWorld.getName().equals(world)) {
-                    path = dynmapServer.getFile(request.getUri());
+                    path = dynmapServer.getFile(request.uri());
                 }
             }
         }
@@ -119,7 +119,7 @@ public class TileFileHandler implements IHandler {
         HandlerUtil.setDateAndCacheHeaders(response, file.lastModified());
 
         response.headers().set(CONTENT_LENGTH, file.length());
-        response.headers().set(CONNECTION, HttpHeaders.Values.CLOSE);
+        response.headers().set(CONNECTION, HttpHeaderValues.CLOSE);
         response.headers().set(VARY, ACCEPT_ENCODING);
 
         // Write the initial line and the header.

--- a/src/main/java/net/cubespace/dynmap/multiserver/HTTP/HandlerUtil.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/HTTP/HandlerUtil.java
@@ -17,7 +17,7 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.regex.Pattern;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_MODIFIED;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;

--- a/src/main/java/net/cubespace/dynmap/multiserver/HttpRemoteDynmapServer.java
+++ b/src/main/java/net/cubespace/dynmap/multiserver/HttpRemoteDynmapServer.java
@@ -15,24 +15,20 @@ public class HttpRemoteDynmapServer extends AbstractDynmapServer {
 
     public HttpRemoteDynmapServer(Dynmap config) {
         super(config);
-        this.url = config.Url;
+        if (config.Url.endsWith("/")) {
+            this.url = config.Url;
+        } else {
+            this.url = config.Url + "/";
+        }
     }
 
     @Override
     public AbstractFile getFile(String path) throws IOException {
         path = path.replace(File.separator, "/");
-        if (url.endsWith("/")) {
-            if (path.startsWith("/")) {
-                return new HttpRemoteFile(url + path.substring(1));
-            } else {
-                return new HttpRemoteFile(url + path);
-            }
+        if (path.startsWith("/")) {
+            return new HttpRemoteFile(url + path.substring(1));
         } else {
-            if (path.startsWith("/")) {
-                return new HttpRemoteFile(url + path);
-            } else {
-                return new HttpRemoteFile(url + "/" + path);
-            }
+            return new HttpRemoteFile(url + path);
         }
     }
 }


### PR DESCRIPTION
- Updated all dependencies and maven plugins.
- Fixed errors caused by dependency updates.
- Fixed compilation and execution with Java >9.
- Adjusted log level for "check worlds" message to debug, causing less spam.
- Cleaned up `pom.xml`:
  - Removed duplicated `maven-jar-plugin`.
  - Defined plugin versions in `pluginManagement`.
  - Used correct repository URL for `md_5` repository.
  - Added `maven-enforce-plugin`.
  - Set encoding to `UTF-8`.

Closes #9 (merged), closes #11, closes #12.